### PR TITLE
fixbug:点击表情后可以直接按Enter件发送消息

### DIFF
--- a/src/views/Home/components/ChatBox/index.vue
+++ b/src/views/Home/components/ChatBox/index.vue
@@ -83,6 +83,8 @@ const insertText = (emoji: string) => {
   input.focus()
   input.selectionStart = startPos + emoji.length
   input.selectionEnd = startPos + emoji.length
+  //临时让获取焦点
+  focusMsgInput()
 }
 </script>
 


### PR DESCRIPTION
用户点击emoji表情后，回复框就获取焦点，这样点击完表情后直接按Enter键就可以发送消息了