### PR TITLE
fix: 修复回复相关样式bug

### DIFF
--- a/src/views/Home/components/ChatBox/styles.scss
+++ b/src/views/Home/components/ChatBox/styles.scss
@@ -37,8 +37,9 @@
     color: var(--font-light);
     display: flex;
     align-items: center;
-    column-gap: 20px;
-    margin-right: 60px;
+    column-gap: 12px;
+    word-wrap: break-word;
+    white-space: pre-wrap;
   }
 
   .reply-msg-content {

--- a/src/views/Home/components/ChatList/MsgItem/index.vue
+++ b/src/views/Home/components/ChatList/MsgItem/index.vue
@@ -116,7 +116,9 @@ onMounted(()=>{
         v-if="msg.message.reply"
         class="chat-item-reply"
       >
-        {{ msg.message.reply.username }}: {{ msg.message.reply.content }}
+        <span class="ellipsis">
+          {{ msg.message.reply.username }}: {{ msg.message.reply.content }}
+        </span>
       </div>
     </div>
   </div>

--- a/src/views/Home/components/ChatList/MsgItem/styles.scss
+++ b/src/views/Home/components/ChatList/MsgItem/styles.scss
@@ -71,17 +71,21 @@
     }
 
     &-reply {
-        display: -webkit-inline-box;
-        -webkit-line-clamp: 4;
-        -webkit-box-orient: vertical;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        font-size: 12px;
+        width: fit-content;
         margin-top: 4px;
-        padding: 3px 12px;
-        border-radius: 8px;
-        color: var(--font-light);
-        background-color: #424656;
+        margin-right: auto;
+        .ellipsis {
+            display: -webkit-inline-box;
+            -webkit-line-clamp: 4;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            font-size: 12px;
+            padding: 4px 12px;
+            border-radius: 8px;
+            color: var(--font-light);
+            background-color: #424656;
+        }
     }
 }
 
@@ -110,6 +114,10 @@
     .chat-item-content {
         margin-left: auto;
         border-radius: 20px 5px 20px 20px;
+    }
+    .chat-item-reply {
+        margin-left: auto;
+        margin-right: 0;
     }
 }
 

--- a/src/views/Home/components/ChatList/styles.scss
+++ b/src/views/Home/components/ChatList/styles.scss
@@ -8,7 +8,7 @@
   overscroll-behavior-y: contain;
   overflow: hidden;
   overflow-y: auto;
-  padding: 20px;
+  padding: 20px 20px 0 20px;
   flex-direction: column;
 
   // 强制硬件加速


### PR DESCRIPTION
## Bug修复

### 问题描述
1. 在自己回复他人消息时回复消息未跟随布局走
2. 回复长文本会导致聊天框撑开全部 界面变形
<img width="502" alt="image" src="https://github.com/Evansy/MallChatWeb/assets/48879481/64b79acd-ed96-4c6d-bfeb-17a6e96832c5">
<img width="832" alt="image" src="https://github.com/Evansy/MallChatWeb/assets/48879481/e12a9b3c-b11b-47ce-a04b-4106c00e6df8">


## Changelog

🐛 问题修复
- 修复回复相关样式bug


| type | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   fix   |  修复回复样式问题     |  Fix reply style related issues   |        |



