### PR TITLE
feat: 增强通知栏

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -17,6 +17,7 @@ declare module '@vue/runtime-core' {
     ElIcon: typeof import('element-plus/es')['ElIcon']
     ElInput: typeof import('element-plus/es')['ElInput']
     ElPopover: typeof import('element-plus/es')['ElPopover']
+    ElTag: typeof import('element-plus/es')['ElTag']
     ElTooltip: typeof import('element-plus/es')['ElTooltip']
     IconCommunity: typeof import('./components/icons/IconCommunity.vue')['default']
     IconDocumentation: typeof import('./components/icons/IconDocumentation.vue')['default']

--- a/src/views/Home/components/ChatBox/styles.scss
+++ b/src/views/Home/components/ChatBox/styles.scss
@@ -37,8 +37,9 @@
     color: var(--font-light);
     display: flex;
     align-items: center;
-    column-gap: 20px;
-    margin-right: 60px;
+    column-gap: 12px;
+    word-wrap: break-word;
+    white-space: pre-wrap;
   }
 
   .reply-msg-content {

--- a/src/views/Home/components/ChatList/MsgItem/index.vue
+++ b/src/views/Home/components/ChatList/MsgItem/index.vue
@@ -116,7 +116,9 @@ onMounted(()=>{
         v-if="msg.message.reply"
         class="chat-item-reply"
       >
-        {{ msg.message.reply.username }}: {{ msg.message.reply.content }}
+        <span class="ellipsis">
+          {{ msg.message.reply.username }}: {{ msg.message.reply.content }}
+        </span>
       </div>
     </div>
   </div>

--- a/src/views/Home/components/ChatList/MsgItem/styles.scss
+++ b/src/views/Home/components/ChatList/MsgItem/styles.scss
@@ -71,17 +71,21 @@
     }
 
     &-reply {
-        display: -webkit-inline-box;
-        -webkit-line-clamp: 4;
-        -webkit-box-orient: vertical;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        font-size: 12px;
+        width: fit-content;
         margin-top: 4px;
-        padding: 3px 12px;
-        border-radius: 8px;
-        color: var(--font-light);
-        background-color: #424656;
+        margin-right: auto;
+        .ellipsis {
+            display: -webkit-inline-box;
+            -webkit-line-clamp: 4;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            font-size: 12px;
+            padding: 4px 12px;
+            border-radius: 8px;
+            color: var(--font-light);
+            background-color: #424656;
+        }
     }
 }
 
@@ -110,6 +114,10 @@
     .chat-item-content {
         margin-left: auto;
         border-radius: 20px 5px 20px 20px;
+    }
+    .chat-item-reply {
+        margin-left: auto;
+        margin-right: 0;
     }
 }
 

--- a/src/views/Home/components/ChatList/styles.scss
+++ b/src/views/Home/components/ChatList/styles.scss
@@ -8,7 +8,7 @@
   overscroll-behavior-y: contain;
   overflow: hidden;
   overflow-y: auto;
-  padding: 20px;
+  padding: 20px 20px 0 20px;
   flex-direction: column;
 
   // 强制硬件加速

--- a/src/views/Home/components/SideBar/index.vue
+++ b/src/views/Home/components/SideBar/index.vue
@@ -1,9 +1,67 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useChatStore } from '@/stores/chat'
+import { formatTimestamp } from '@/utils/computedTime'
+import mallChatLogo from '@/assets/logo.jpeg'
+
+// 选中的聊天对话
+const activeChat = ref(1)
+const chatStore = useChatStore()
+
+// 计算最后一条消息
+const lastMassage = computed(() => {
+  return chatStore.chatMessageList?.[chatStore.chatMessageList?.length - 1]
+})
+
+// mock数据等后端接口完成后变动
+const mockData = ref([
+  {
+    id: 1,
+    msgName: 'MallChat 用户群',
+    name: lastMassage.value?.fromUser?.username,
+    avatar: mallChatLogo,
+    tag: '官方',
+    lastMsg: lastMassage.value?.message?.content || '欢迎使用MallChat',
+    lastMsgTime: formatTimestamp(lastMassage.value?.message?.sendTime),
+  },
+  {
+    id: 2,
+    msgName: '通知',
+    name: '机器人',
+    avatar: mallChatLogo,
+    tag: '机器人',
+    lastMsg: '欢迎使用MallChat',
+    lastMsgTime: '13:54',
+  }
+])
+
+// 最后一条消息变化就把MoakData更新
+watch(lastMassage, (newVal) => {
+  mockData.value[0].name = newVal?.fromUser?.username
+  mockData.value[0].lastMsg = newVal?.message?.content
+  mockData.value[0].lastMsgTime = formatTimestamp(newVal?.message?.sendTime)
+})
+</script>
 
 <template>
-  <ul class="list">
-    <li class="item active"><img class="item-avatar" src="@/assets/logo.jpeg" alt="群聊" />抹茶群聊</li>
-  </ul>
+  <div class="chat-message">
+    <div
+      v-for="(item, index) in mockData"
+      :key="index"
+      :class="['chat-message-item ', { active: activeChat === item.id }]"
+      @click="activeChat = item.id"
+    >
+      <el-avatar shape="circle" :size="38" :src="item.avatar" />
+      <div class="message-info">
+        <div style="white-space: nowrap">
+          <span class="person">{{ item.msgName }}</span>
+          <span v-if="item.tag" class="tag">{{ item.tag }}</span>
+        </div>
+        <div class="message-message">{{ item.name + '：' + item.lastMsg }}</div>
+      </div>
+      <span class="message-time">{{ item.lastMsgTime }}</span>
+    </div>
+  </div>
 </template>
 
 <style lang="scss" src="./styles.scss" scoped />

--- a/src/views/Home/components/SideBar/styles.scss
+++ b/src/views/Home/components/SideBar/styles.scss
@@ -1,40 +1,78 @@
-.list {
+.chat-message {
   display: none;
-  list-style-type: none;
-  padding-left: 10px;
-  padding-right: 20px;
+  margin: 20px 10px;
+  padding: 4px;
+  overflow-y: auto;
+
+  &-item {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 280px;
+    height: 60px;
+    border-radius: 8px;
+    color: var(--el-color-info-light-7);
+    background-color: var(--color-gray-bg);
+    padding: 12px 10px;
+    cursor: pointer;
+    
+    .el-avatar {
+      flex: none;
+    }
+
+    .message-info {
+      margin-right: auto;
+      padding: 0 10px;
+
+      .person {
+        font-size: 14px;
+      }
+
+      .tag {
+        display: inline-block;
+        font-size: 12px;
+        transform: scale(0.8);
+        font-weight: bold;
+        color: #c59512;
+        background-color: #EFE2BB;
+        border-radius: 4px;
+        padding: 1px 4px;
+        margin-left: 4px;
+      }
+
+      .message-message {
+        font-size: 12px;
+        color: var(--font-light);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 1;
+      }
+    }
+
+    .message-time {
+      font-size: 12px;
+      color: var(--font-light);
+    }
+  
+    &:hover {
+      background-color: #484d5f;
+      transition: .3s;
+    }
+    &:not(:first-child) {
+      margin-top: 4px;
+    }
+
+    &.active {
+      background-color: var(--vt-c-indigo);
+    }
+  }
 }
 
 @media only screen and (min-width: 1400px) {
-  .list {
+  .chat-message {
     display: block;
   }
-}
-
-.item {
-  width: 250px;
-  height: 80px;
-  border-radius: 8px;
-  background-color: var(--color-gray-bg);
-  position: relative;
-  margin: 24px 0;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  padding: 0 24px;
-
-  &.active,
-  &:hover {
-    background-color: var(--color-primary);
-    transition: .3s;
-    box-shadow: 0 0 10px 0 #08f;
-  }
-}
-
-.item-avatar {
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-  position: relative;
-  margin-right: 20px;
 }

--- a/src/views/Home/components/ToolBar/styles.scss
+++ b/src/views/Home/components/ToolBar/styles.scss
@@ -100,9 +100,3 @@
     }
   }
 }
-
-@media only screen and (min-width: 1200px) {
-  .side_toolbar {
-    width: 100px;
-  }
-}


### PR DESCRIPTION
## 通知栏更新

### 问题描述
当前版本的通知栏无实际作用，比例不协调等细节问题。
<img width="1177" alt="image" src="https://github.com/Evansy/MallChatWeb/assets/48879481/5135f862-cfc2-47e5-b8ea-5836cc56f96f">

## 解决方案
调整新的样式，菜单项有数据循环生成。mock预留给后期更新为后端实时会话信息以及其他模块数据。
#### 特性
- 实时通知显示最后一条消息
- 针对不同的会话显示不同的`Tag`

## Changelog

🆕 新增功能
- 实时会话信息

💅 样式更新
-  调整通知栏的样式结构与布局占比
- 移除不必要的side_toolbar媒体查询样式

| type | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   feat   |  增强通知栏     |  Enhance message notification bar    |          |

## 预览

https://github.com/Evansy/MallChatWeb/assets/48879481/452849f2-9645-4975-80a8-f9259e815ad6




