### PR TITLE
feat: 单个消息超过5行时可选择展开收起

### DIFF
--- a/src/components/RenderMsg.tsx
+++ b/src/components/RenderMsg.tsx
@@ -1,26 +1,82 @@
-import { defineComponent } from 'vue'
+import { defineComponent, onMounted, onUnmounted, ref, nextTick, computed } from 'vue'
+import { debounce } from 'lodash'
 import DOMPurify from 'dompurify'
+import { ArrowUp, ArrowDown } from '@element-plus/icons-vue'
+import './renderMsg.scss'
 
 export default defineComponent({
-  props: ['urlMap', 'text', 'isMe'],
-  setup(props) {
+  props: ['urlMap', 'text', 'isMe', 'msg'],
+  emits: ['updateTooltip'],
+  setup(props, ctx) {
+    const divRef = ref()
+    // 渲染的html字符串
+    const result = ref('')
+    // 是否需要显示展开收起的按钮，取决于文字行数
+    const needCollapse = ref(false)
+    const collapseIcon = computed(() =>
+      props.msg.message.isCollapse ? <ArrowDown class="collapse-icon" /> : <ArrowUp class="collapse-icon" />,
+    )
+    const isPlainText = !props.urlMap || !Object.keys(props.urlMap).length
+
+    if (isPlainText) {
+      result.value = ref(props.text)
+    }
+    result.value = DOMPurify.sanitize(props.text, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] })
+    for (const [url, title] of Object.entries(props.urlMap)) {
+      result.value = result.value?.replace(
+        url,
+        `<a rel="noopener noreferrer nofollow" target="_blank" class="msg-content-link" style="color: ${
+          props.isMe ? '#fff' : 'var(--color-primary)'
+        };" href="${url.includes('http') ? url : `//${url}`}">${title}</a>`,
+      )
+    }
+
+    const isNeedCollapse = () => {
+      // TODO: 这里未来可以考虑更好的方法去判断行数
+      nextTick(() => {
+        divRef.value && (needCollapse.value = +(divRef.value.clientHeight / 22.5).toFixed(0) > 5)
+      })
+    }
+    const isNeedCollapseDebounce = debounce(isNeedCollapse, 300)
+
+    onMounted(() => {
+      // 刚开始渲染的时候不能用防抖
+      isNeedCollapse()
+      window.addEventListener('resize', isNeedCollapseDebounce)
+    })
+
+    onUnmounted(() => {
+      window.removeEventListener('resize', isNeedCollapseDebounce)
+    })
+
+    const onToggleCollapse = () => {
+      // 由于使用了虚拟列表所以需要在数据源上设置是否展开的标志位，
+      // TODO: 这里改变props的方式也不是太好，未来有可能改成emit，或者去状态中取;但目前来看比较方便
+      // eslint-disable-next-line vue/no-mutating-props
+      props.msg.message.isCollapse = !props.msg.message.isCollapse
+      nextTick(() => {
+        ctx.emit('updateTooltip')
+      })
+    }
+
     return () => {
-      if (!props.urlMap || Object.keys(props.urlMap).length === 0) return props.text
-
-      // 先过滤所有标签
-      const clean = DOMPurify.sanitize(props.text, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] })
-
-      // 再替换标签，保证用户输入的内容是干净的
-      let result = clean
-      for (const [url, title] of Object.entries(props.urlMap)) {
-        result = result?.replace(
-          url,
-          `<a rel="noopener noreferrer nofollow" target="_blank" class="msg-content-link" style="color: ${
-            props.isMe ? '#fff' : 'var(--color-primary)'
-          };" href="${url.includes('http') ? url : `//${url}`}">${title}</a>`,
-        )
-      }
-      return <div v-html={result} />
+      return (
+        <>
+          <div
+            v-html={result.value}
+            ref={divRef}
+            class={{
+              'msg-item': true,
+              collapse: needCollapse.value && props.msg.message.isCollapse,
+            }}
+          />
+          {needCollapse.value ? (
+            <div class="collapse-box" onClick={onToggleCollapse}>
+              {collapseIcon.value}
+            </div>
+          ) : null}
+        </>
+      )
     }
   },
 })

--- a/src/components/renderMsg.scss
+++ b/src/components/renderMsg.scss
@@ -1,0 +1,19 @@
+.msg-item {
+  &.collapse {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 5; /* 指定需要显示的行数 */
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.collapse-box {
+  height: 20px;
+  text-align: center;
+
+  .collapse-icon {
+    height: 20px;
+    cursor: pointer;
+  }
+}

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -139,6 +139,10 @@ export type MessageItemContentType = {
    * 消息中的链接
    */
   urlTitleMap: Record<string, string>
+  /**
+   * 消息发送时间
+   */
+  isCollapse?: boolean
 }
 
 export type MessageItemType = {

--- a/src/views/Home/components/ChatList/MsgItem/index.vue
+++ b/src/views/Home/components/ChatList/MsgItem/index.vue
@@ -11,6 +11,7 @@ import MsgOption from '../MsgOption/index.vue'
 import type { TooltipTriggerType } from 'element-plus/es/components/tooltip/src/trigger'
 import { copyToClip } from '@/utils/copy'
 import { useLikeToggle } from '@/hooks/useLikeToggle'
+import { ElTooltip } from 'element-plus'
 
 const props = defineProps({
   // 消息体
@@ -55,6 +56,7 @@ const boxRef = ref<HTMLElement | null>(null)
 const tooltipPlacement = ref()
 const virtualListRef = inject<Ref>('virtualListRef')
 const { isLike, isDisLike, likeCount, dislikeCount, onLike, onDisLike } = useLikeToggle(props.msg.message)
+const tooltipRef = ref<InstanceType<typeof ElTooltip> | null>(null)
 
 // 滚动到消息
 const scrollToMsg = async (msg: MessageItemContentType) => {
@@ -111,6 +113,11 @@ onMounted(() => {
     }
   })
 })
+
+// 触发Tooltip更新显示位置
+const updateTooltip = () => {
+  tooltipRef.value && tooltipRef.value.updatePopper()
+}
 </script>
 
 <template>
@@ -138,6 +145,7 @@ onMounted(() => {
       </div>
       <el-tooltip
         effect="light"
+        ref="tooltipRef"
         popper-class="option-tooltip"
         :trigger="tooltipTrigger"
         :placement="tooltipPlacement || 'bottom-end'"
@@ -150,7 +158,13 @@ onMounted(() => {
           <MsgOption :msg="msg" />
         </template>
         <div class="chat-item-content" ref="renderMsgRef" @contextmenu.prevent.stop="handleRightClick($event, msg)">
-          <RenderMsg :text="msg.message.content.trim()" :url-map="msg.message.urlTitleMap" :is-me="isCurrentUser" />
+          <RenderMsg
+            :text="msg.message.content.trim()"
+            :url-map="msg.message.urlTitleMap"
+            :is-me="isCurrentUser"
+            :msg="msg"
+            @updateTooltip="updateTooltip"
+          />
         </div>
       </el-tooltip>
       <div


### PR DESCRIPTION

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 组件样式/交互改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 其他改动（是关于什么的改动？）

## 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fix #xxxx
-->

### 💡 需求背景和解决方案

1. 当消息内容过长时占据整体屏幕较大，为此增加展开收起消息功能

<img width="746" alt="image" src="https://github.com/Evansy/MallChatWeb/assets/40224384/4c68dc8e-7c70-49e1-9cda-4eee2372f4db">
<img width="740" alt="image" src="https://github.com/Evansy/MallChatWeb/assets/40224384/8970aa8c-b9f1-476c-900e-6b0508011cd7">

### 📝 更新日志


| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |     当单个消息行数超过5行时显示展开和收起的icon    |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述



### 🔍 实现细节

主要考虑以下case：
1. 由于采用了虚拟列表，在点击收起展开按钮后，其展开和收起状态应保存在源数据数组中，这样当上下滚动时，其消息组件会被重新创建，也就能缓存记录用户点击收起和展开的记录；
2. 当页面窗口大小发生变化后，需要重新计算消息行数；
3. 消息函数的计算逻辑通过组件挂载onMounted钩子来计算盒子高度并处以单行高度22.5，并四舍五入；
4. 消息的气泡即点赞按钮所在box，需要在展开收起后立即重新计算位置。
