### PR TITLE
chore(custom): 解决mac提交代码git hooks 报错问题,使用npm run commi…

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -1,0 +1,44 @@
+module.exports = {
+  // type 类型（定义之后，可通过上下键选择）
+  types: [
+    { value: 'feat', name: '🌟 feat:    新增feature' },
+    { value: 'fix', name: '🐛 fix:     修复 bug' },
+    { value: 'perf', name: '🚀 perf:    优化相关，比如性能、体验的提升' },
+    { value: 'style', name: '🎨 style:   仅仅修改了空格、格式缩进、逗号等等，不改变代码逻辑' },
+    { value: 'docs', name: '📝 docs:    仅仅修改了文档，比如README, CHANGELOG, CONTRIBUTE等等;' },
+    { value: 'test', name: '👷 test:    测试用例，包括单元测试、集成测试等' },
+    { value: 'refactor', name: '🔀 refactor: 代码重构，没有加新功能或者修复bug' },
+    { value: 'build', name: '🔨 build:   ' },
+    { value: 'ci', name: '🤖 ci:' },
+    { value: 'chore', name: 'chore: 改变构建流程、或者增加依赖库、工具等' },
+    { value: 'revert', name: '⏪ revert:回滚 commit' },
+    { value: 'wip', name: 'wip:' },
+    { value: 'workflow', name: 'workflow:' },
+    { value: 'types', name: 'types:' },
+    { value: 'release', name: 'release:' },
+  ],
+  // 交互提示信息
+  messages: {
+    type: '确保本次提交遵循 规范！\n选择你要提交的类型：',
+    scope: '\n选择一个 scope（可选）：',
+    // 选择 scope: custom 时会出下面的提示
+    customScope: '请输入自定义的 scope：',
+    subject: '填写简短精炼的变更描述：\n',
+    body: '填写更加详细的变更描述（可选）。使用 "|" 换行：\n',
+    breaking: '列举非兼容性重大的变更（可选）：\n',
+    footer: '列举出所有变更的 ISSUES CLOSED（可选）。 例如: #31, #34：\n',
+    confirmCommit: '确认提交？',
+  },
+
+  // 设置只有 type 选择了 feat 或 fix，才询问 breaking message
+  allowBreakingChanges: ['feat', 'fix'],
+
+  // 跳过要询问的步骤
+  // skipQuestions: ['body', 'footer'],
+
+  // subject 限制长度
+  subjectLimit: 100,
+  breaklineChar: '|', // 支持 body 和 footer
+  // footerPrefix : 'ISSUES CLOSED:'
+  // askForBreakingChangeFirst : true,
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,13 @@
     "link:format": "prettier --write src/",
     "link:lint-staged": "lint-staged -c ./.husky/lintstagedrc.js",
     "lint:style": "stylelint --fix \"src/**/*.{css,scss,vue}\"",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "commit": "git add . && git cz"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-customizable"
+    }
   },
   "dependencies": {
     "@alova/scene-vue": "^1.0.4",
@@ -47,6 +53,9 @@
     "@vue/eslint-config-prettier": "^7.1.0",
     "@vue/eslint-config-typescript": "^11.0.3",
     "@vue/tsconfig": "^0.1.3",
+    "commitizen": "^4.3.0",
+    "cz-conventional-changelog": "^3.3.0",
+    "cz-customizable": "^6.9.2",
     "eslint": "^8.40.0",
     "eslint-plugin-vue": "^9.11.0",
     "husky": "^8.0.3",


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

PR 请提到 develop 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？ (至少选中一项)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 组件样式/交互改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 包体积优化
- [ ] 性能优化
- [X] 其他改动（是关于什么的改动？）
mac提交代码git hooks 报错问题
## 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fix #xxxx
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     To solve the problem of git hooks error in mac submission code, use npm run commit to trigger git hooks     |
| 🇨🇳 中文 |     解决mac提交代码git hooks 报错问题,使用npm run commit来触发git hooks     |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [X] TypeScript 定义已补充或无须补充
- [X] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述
> 修改之前:
<img width="770" alt="image" src="https://github.com/Evansy/MallChatWeb/assets/44251294/bb6ef425-eee2-477a-82a1-5ddecf6de792">

> 修改之后:
<img width="741" alt="image" src="https://github.com/Evansy/MallChatWeb/assets/44251294/1921f52c-f2ff-4a68-8a7f-de15c26cff18">

copilot:summary

### 🔍 实现细节

copilot:walkthrough
