### PR TITLE
fix: 获取chat-item offsetHeight 可能与实际渲染高度不一致的问题

### DIFF
--- a/src/components/VirtualList/item.tsx
+++ b/src/components/VirtualList/item.tsx
@@ -46,8 +46,9 @@ export default defineComponent({
      */
     const dispatchSizeChange = () => {
       const { uniqueKey } = props
-      const size = rootRef.value ? rootRef.value.offsetHeight : 0 // 当前项的高度
-      emit('itemResize', uniqueKey, size)
+      // 使用 getBoundingClientRect 获取元素的大小 更为准确些
+      const rect = rootRef.value ? rootRef.value.getBoundingClientRect() : 0
+      emit('itemResize', uniqueKey, rect ? rect.height : 0)
     }
 
     onMounted(() => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

PR 请提到 develop 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？ (至少选中一项)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [x] 组件样式/交互改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 其他改动（是关于什么的改动？）

## 🔗 相关 Issue
解决了一部分问题
#55 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fix #xxxx
-->

### 💡 需求背景和解决方案
获取每个item offsetHeight 可能存在误差。原因是实际高度可能存在小数点，但是offsetHeight获取到了整数值。
当onscorll触发 Virtual.checkRange，改变虚拟列表渲染范围时,会导致抖动。消息越长，抖动可能越明显。

https://github.com/Evansy/MallChatWeb/assets/23380976/9c13f7a2-82dd-4f8d-8e5b-4c81e438fbc4

解决方案：
使用 getBoundingClientRect 来获取item的高度。

https://github.com/Evansy/MallChatWeb/assets/23380976/e297f2b0-d933-4444-b26b-a5e4c15a97f7



使用后，明显看到更丝滑
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述

copilot:summary

### 🔍 实现细节

copilot:walkthrough
