### PR TITLE
fix: 修复撤回消息左侧还能看到原消息问题

### DIFF
--- a/src/views/Home/components/SideBar/index.vue
+++ b/src/views/Home/components/SideBar/index.vue
@@ -36,11 +36,16 @@ const mockData = ref([
 ])
 
 // 最后一条消息变化就把MoakData更新
-watch(lastMassage, (newVal) => {
-  mockData.value[0].name = newVal?.fromUser?.username
-  mockData.value[0].lastMsg = newVal?.message?.body?.content
-  mockData.value[0].lastMsgTime = formatTimestamp(newVal?.message?.sendTime)
-})
+watch(
+  lastMassage,
+  (newVal) => {
+    const { fromUser, message } = newVal
+    mockData.value[0].name = fromUser?.username
+    mockData.value[0].lastMsg = message.type === 2 ? '撤回了一条消息' : message.body?.content
+    mockData.value[0].lastMsgTime = formatTimestamp(message.sendTime)
+  },
+  { deep: true },
+)
 </script>
 
 <template>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

PR 请提到 develop 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？ (至少选中一项)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 组件样式/交互改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 其他改动（是关于什么的改动？）

## 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fix #xxxx
-->

### 💡 需求背景和解决方案

<img width="688" alt="image" src="https://github.com/Evansy/MallChatWeb/assets/48879481/7703ad4c-75b5-40ee-8667-14d694e3b4d1">

### 📝 更新日志


| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |  Fix displaying original message on the left after message retraction        |
| 🇨🇳 中文 |   修复撤回消息左侧还能看到原消息       |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述

copilot:summary

### 🔍 实现细节

copilot:walkthrough
