### PR TITLE
fix：更换图片下载方式，修复点击下载之后跳转新标签页但不发起下载的问题

### DIFF
--- a/src/views/Home/components/ChatList/ContextMenu/index.vue
+++ b/src/views/Home/components/ChatList/ContextMenu/index.vue
@@ -70,11 +70,25 @@ const download = () => {
   const { body } = props.msg.message
   const url = body?.url
   if (!url) return
-  const a = document.createElement('a')
-  a.href = url
-  a.download = body.fileName || '未知文件'
-  a.click()
-  a.remove()
+
+  const xhr = new XMLHttpRequest()
+  xhr.open('GET', url, true)
+  xhr.responseType = 'blob'
+
+  xhr.onreadystatechange = () => {
+    // 下载失败提示
+    if (xhr.status != 200) return ElMessage.error('下载失败~')
+    if (xhr.readyState === 4 && xhr.status === 200) {
+      const blob = xhr.response
+      let link = document.createElement('a')
+      link.href = URL.createObjectURL(blob)
+      link.download = body.fileName || '未知文件'
+      link.dispatchEvent(new MouseEvent('click'))
+      link.remove()
+    }
+  }
+
+  xhr.send()
 }
 
 const onDelete = () => chatStore.deleteMsg(props.msg.message.id)


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

PR 请提到 main 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？ (至少选中一项)

- [*] 日常 bug 修复
- [ ] 新特性提交
- [ ] 组件样式/交互改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 其他改动（是关于什么的改动？）

## 🔗 相关 Issue
通过测试发现，点击下载之后会跳转到新页面，但没有发起下载请求，削减了用户体检

### 💡 需求背景和解决方案
在原来的基础之前，更换成请求的放下再下载，避免上述问题

### 📝 更新日志
更换图片下载方式，修复点击下载之后跳转新标签页但不发起下载的问题

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |            |
| 🇨🇳 中文 |    *      |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [*] 文档已补充或无须补充
- [*] 代码演示已提供或无须提供
- [*] TypeScript 定义已补充或无须补充
- [*] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述

copilot:summary

### 🔍 实现细节

copilot:walkthrough
