### PR TITLE
perf: 当未登录时，右键菜单只有复制按钮时，多余的分割线看着很不协调

### DIFF
--- a/src/views/Home/components/ChatList/ContextMenu/index.vue
+++ b/src/views/Home/components/ChatList/ContextMenu/index.vue
@@ -33,8 +33,7 @@ const props = defineProps({
 
 const emojiStore = useEmojiStore()
 const { uploadEmoji } = useEmojiUpload()
-const userStore = useUserStore()
-const userInfo = userStore?.userInfo
+const userInfo = useUserStore()?.userInfo
 const chatStore = useChatStore()
 // FIXME 未登录到登录这些监听没有变化。需处理
 const isCurrentUser = computed(() => props.msg?.fromUser.uid === userInfo.uid)
@@ -152,7 +151,7 @@ const onDelete = () => chatStore.deleteMsg(props.msg.message.id)
         <Icon icon="xiazai" :size="15" />
       </template>
     </ContextMenuItem>
-    <ContextMenuSeparator v-if="isShowMenuSeparator" />
+    <ContextMenuSeparator v-login-show />
     <ContextMenuItem label="删除" @click="onDelete" v-login-show>
       <template #icon>
         <Icon icon="shanchu" :size="13" />

--- a/src/views/Home/components/ChatList/ContextMenu/index.vue
+++ b/src/views/Home/components/ChatList/ContextMenu/index.vue
@@ -33,11 +33,13 @@ const props = defineProps({
 
 const emojiStore = useEmojiStore()
 const { uploadEmoji } = useEmojiUpload()
-const userInfo = useUserStore()?.userInfo
+const userStore = useUserStore()
+const userInfo = userStore?.userInfo
 const chatStore = useChatStore()
 // FIXME 未登录到登录这些监听没有变化。需处理
 const isCurrentUser = computed(() => props.msg?.fromUser.uid === userInfo.uid)
 const isAdmin = computed(() => userInfo?.power === PowerEnum.ADMIN)
+const isShowMenuSeparator = computed(() => userStore.isSign)
 
 // 撤回
 const onRecall = async () => {
@@ -150,7 +152,7 @@ const onDelete = () => chatStore.deleteMsg(props.msg.message.id)
         <Icon icon="xiazai" :size="15" />
       </template>
     </ContextMenuItem>
-    <ContextMenuSeparator />
+    <ContextMenuSeparator v-if="isShowMenuSeparator" />
     <ContextMenuItem label="删除" @click="onDelete" v-login-show>
       <template #icon>
         <Icon icon="shanchu" :size="13" />

--- a/src/views/Home/components/ChatList/ContextMenu/index.vue
+++ b/src/views/Home/components/ChatList/ContextMenu/index.vue
@@ -38,7 +38,6 @@ const chatStore = useChatStore()
 // FIXME 未登录到登录这些监听没有变化。需处理
 const isCurrentUser = computed(() => props.msg?.fromUser.uid === userInfo.uid)
 const isAdmin = computed(() => userInfo?.power === PowerEnum.ADMIN)
-const isShowMenuSeparator = computed(() => userStore.isSign)
 
 // 撤回
 const onRecall = async () => {

--- a/src/views/Home/components/ChatList/MsgItem/index.vue
+++ b/src/views/Home/components/ChatList/MsgItem/index.vue
@@ -98,6 +98,11 @@ const scrollToMsg = async (msg: MsgType) => {
 
 /** 右键菜单 */
 const handleRightClick = (e: MouseEvent) => {
+  // perf: 未登录时，禁用右键菜单功能
+  if (!userStore.isSign) {
+    return
+  }
+
   // TODO：看它源码里提供了一个transformMenuPosition函数可以控制在容器范围内弹窗 我试验了一下报错
   // https://github.com/imengyu/vue3-context-menu/blob/f91a4140b4a425fa2770449a8be3570836cdfc23/examples/views/ChangeContainer.vue#LL242C5-L242C5
   const { x, y } = e

--- a/src/views/Home/components/ChatList/MsgItem/index.vue
+++ b/src/views/Home/components/ChatList/MsgItem/index.vue
@@ -184,7 +184,7 @@ onMounted(() => {
             <span
               v-if="likeCount > 0"
               :class="['extra-item like', { active: isLike }]"
-              @click="onLike"
+              v-login="onLike"
             >
               <Icon icon="like" />
               <transition name="count-up" mode="out-in">
@@ -196,7 +196,7 @@ onMounted(() => {
             <span
               v-if="dislikeCount > 0"
               :class="['extra-item dlike', { active: isDisLike }]"
-              @click="onDisLike"
+              v-login="onDisLike"
             >
               <Icon icon="dislike" :size="17" />
               <transition name="count-up" mode="out-in">

--- a/src/views/Home/components/UserList/UserItem/index.vue
+++ b/src/views/Home/components/UserList/UserItem/index.vue
@@ -4,6 +4,7 @@ import type { PropType } from 'vue'
 import { OnlineEnum } from '@/enums'
 import type { UserItem } from '@/services/types'
 import { useUserInfo } from '@/hooks/useCached'
+import { useUserStore } from '@/stores/user'
 import ContextMenu from '../ContextMenu/index.vue'
 const props = defineProps({
   user: {
@@ -19,6 +20,11 @@ const menuOptions = ref({ x: 0, y: 0 })
 
 /** 右键菜单 */
 const handleRightClick = (e: MouseEvent) => {
+  // 根据右键菜单上下文分析，未登录时禁用右键菜单功能
+  if (!useUserStore().isSign) {
+    return
+  }
+
   // TODO：看它源码里提供了一个transformMenuPosition函数可以控制在容器范围内弹窗 我试验了一下报错
   // https://github.com/imengyu/vue3-context-menu/blob/f91a4140b4a425fa2770449a8be3570836cdfc23/examples/views/ChangeContainer.vue#LL242C5-L242C5
   const { x, y } = e


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

PR 请提到 main 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？ (至少选中一项)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 组件样式/交互改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 包体积优化
- [x] 性能优化
- [ ] 其他改动（是关于什么的改动？）

## 🔗 相关 Issue
无

### 💡 需求背景和解决方案

优化未登录时，右键菜单多余的分割线。如下图所示：
优化前：
![image](https://github.com/Evansy/MallChatWeb/assets/107396800/cb822d2b-4f27-4f18-97e9-b7fb6b4a76e5)
优化后：
![image](https://github.com/Evansy/MallChatWeb/assets/107396800/4b5b47ca-e7b8-4905-97ac-ced899e962ac)


### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |  优化未登录时，右键菜单分割线样式     |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述

copilot:summary

### 🔍 实现细节

copilot:walkthrough
